### PR TITLE
Truncate inputs larger than context window instead of crashing

### DIFF
--- a/tests/test-loadable.py
+++ b/tests/test-loadable.py
@@ -140,6 +140,9 @@ def test_lembed():
     assert struct.unpack("1f", a[0:4])[0] == pytest.approx(
         -0.09205757826566696, rel=1e-2
     )
+    
+    # test input larger than default 512 tokens
+    lembed('ab' * 1000)
 
 
 @pytest.mark.skip(reason="TODO")


### PR DESCRIPTION
This should "fix" https://github.com/asg017/sqlite-lembed/issues/7

Not sure this is doing the right thing tbh, feedback welcome:
- Currently silently truncating the input. Making truncation optional runs the risk of most people never using the option and randomly exploding when they finally use larger inputs (in prod).
- Aligned n_batch = n_ubatch = n_ctx to avoid crashes in llama.cpp. Possibly very inefficient? Also, default to the model's n_ctx_train.

Tested w/ `all-MiniLM-L6-v2.e4ce9877.q8_0.gguf` & `nomic-embed-text-v1.5.Q8_0.gguf`.